### PR TITLE
Add a fence for controllerDefinition to be a function

### DIFF
--- a/src/stimulus-controller-resolver.js
+++ b/src/stimulus-controller-resolver.js
@@ -53,6 +53,8 @@ export default class StimulusControllerResolver {
 
       const controllerDefinition = await this.resolverFn(controllerName)
 
+      if (typeof controllerDefinition != "function") { return }
+
       this.application.register(controllerName, controllerDefinition)
       delete this.loadingControllers[controllerName]
     }


### PR DESCRIPTION
Currently, the `loadController` function assumes that anything the `resolveFn` returns would be a controller constructor. 

However, sometimes I need the `resolverFn` to return out – as the looked up controller might be defined elsewhere. (I would like to use the `StimulusControllerResolver` in multiple places in my app.)

An example would be:
```js
const context = require.context("../controllers", true, /\.js$/, "lazy")
const controllerMap = {}

// build a map of controller name & path
// { name-controller: "./nameController.js" }
context.keys().forEach(path => controllerMap[identifierForContextKey(path)] = path)

StimulusControllerResolver.install(application, async (controllerName) => {
  const path = controllerMap[controllerName]
  // if the requested controller is not defined in the map, return out
  if (path == undefined) { return }
  return (await context(path)).default
})
```