### PR TITLE
Make controller attribute name dynamic

### DIFF
--- a/src/stimulus-controller-resolver.js
+++ b/src/stimulus-controller-resolver.js
@@ -33,7 +33,7 @@ export default class StimulusControllerResolver {
   }
 
   loadStimulusControllers(element) {
-    const controllerNames = element.getAttribute('data-controller').split(/\s+/)
+    const controllerNames = element.getAttribute(this.application.schema.controllerAttribute).split(/\s+/)
 
     controllerNames.forEach((controllerName) =>
       this.loadController(controllerName)


### PR DESCRIPTION

It's possible to adjust Stimulus's schema, for example to use `data-stimulus-controller` instead of the default `data-controller`.

This fix makes sure the resolver uses the correct property name.